### PR TITLE
Compile for Windows 7+ on MinGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you don't have cl or nmake, they come with Visual Studio (or the Windows SDK,
 
 Additionally, it is possible to build hotcorner on Linux using MinGW.
 
- `$ x86_64-w64-mingw32-gcc -O2 hotcorner.c -o hotcorner.exe -Wl,-subsystem,windows`
+ `$ x86_64-w64-mingw32-gcc -D_WIN32_WINNT=0x0601 -O2 hotcorner.c -o hotcorner.exe -Wl,-subsystem,windows`
 
 
 ### Configuration


### PR DESCRIPTION
According to https://msdn.microsoft.com/en-us/library/windows/desktop/ms646309(v=vs.85).aspx MOD_NOREPEAT flag is not supported before Windows 7, hence we need to set a correct _WIN32_WINNT value for mingw-w64.